### PR TITLE
fix(packer-vue2): packer vue2 building

### DIFF
--- a/packages/packer-vue2/src/conf/webpack.client.ts
+++ b/packages/packer-vue2/src/conf/webpack.client.ts
@@ -50,15 +50,20 @@ export const getConfig = function getConfig(base: WebpackOptions, option: GetCon
   config.module.rules.push(
     {
       test: /\.tsx?$/,
-      loader: 'ts-loader',
-      options: {
-        appendTsSuffixTo: [/\.vue$/],
-        transpileOnly: true,
-        compilerOptions: {
-          target: 'es5',
-          esModuleInterop: true,
+      use: [
+        {
+          loader: 'ts-loader',
+          options: {
+            appendTsSuffixTo: [/\.vue$/],
+            transpileOnly: true,
+            compilerOptions: {
+              target: 'es5',
+              esModuleInterop: true,
+            },
+          },
         },
-      },
+        '@riejs/packer-utils/lib/loaders/client-fetch-loader',
+      ],
     },
     {
       test: /\.jsx?$/,

--- a/packages/packer-vue2/src/utlis/template.ts
+++ b/packages/packer-vue2/src/utlis/template.ts
@@ -1,5 +1,22 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
+import { URL } from 'url';
+
+/**
+ * /xxx 和 a.js 进行拼接，得到 /xxx/a.js
+ * https://xxx.com 和 a.js 进行拼接，得到 https://xxx.com/a.js
+ * @param {string} base 基础路径
+ * @param {string} asset 资源路径
+ * @returns {string}
+ */
+function resolver(base: string, asset: string) {
+  const dist = /\/$/.test(base) ? base : `${base}/`;
+  // 链接是 http://, https://, 则为 url 链接
+  if (/^https?:\/\//i.test(dist)) {
+    return new URL(asset, dist).href;
+  }
+  return join(dist, asset);
+}
 
 const initScript = isDev => `
   <script>
@@ -41,8 +58,8 @@ export const getClientTemplate = function getServerTemplate(template: string, { 
   const headScripts = [];
   manifest.initial.forEach((asset: string) => {
     const script = asset.match(/\.js$/)
-      ? `<script defer src="${resolve(publicPath, asset)}"></script>`
-      : `<link rel="stylesheet" herf="${resolve(publicPath, asset)}" >`;
+      ? `<script defer src="${resolver(publicPath, asset)}"></script>`
+      : `<link rel="stylesheet" herf="${resolver(publicPath, asset)}" >`;
     headScripts.push(script);
   });
   headScripts.push('</head>');

--- a/packages/renderer-vue2/src/server.ts
+++ b/packages/renderer-vue2/src/server.ts
@@ -1,9 +1,26 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
+import { URL } from 'url';
 import { RendererInterface, RendererOption } from '@riejs/rie';
 import { BaseContext } from 'koa';
 import * as Vue from 'vue';
 import { createBundleRenderer, BundleRenderer } from 'vue-server-renderer';
+
+/**
+ * /xxx 和 a.js 进行拼接，得到 /xxx/a.js
+ * https://xxx.com 和 a.js 进行拼接，得到 https://xxx.com/a.js
+ * @param {string} base 基础路径
+ * @param {string} asset 资源路径
+ * @returns {string}
+ */
+function resolver(base: string, asset: string) {
+  const dist = /\/$/.test(base) ? base : `${base}/`;
+  // 链接是 http://, https://, 则为 url 链接
+  if (/^https?:\/\//i.test(dist)) {
+    return new URL(asset, dist).href;
+  }
+  return join(dist, asset);
+}
 
 class Renderer implements RendererInterface {
   public static type = '@riejs/renderer-vue2';
@@ -126,14 +143,14 @@ class Renderer implements RendererInterface {
         ...clientManifest,
         publicPath: '',
         all: runtime.all
-          .map(asset => resolve(runtimePublicPath, asset))
-          .concat(app.all.map(asset => resolve(publicPath, asset))),
+          .map(asset => resolver(runtimePublicPath, asset))
+          .concat(app.all.map(asset => resolver(publicPath, asset))),
         async: runtime.async
-          .map(asset => resolve(runtimePublicPath, asset))
-          .concat(asyncFiles.map(asset => resolve(publicPath, asset))),
+          .map(asset => resolver(runtimePublicPath, asset))
+          .concat(asyncFiles.map(asset => resolver(publicPath, asset))),
         initial: runtime.initial
-          .map(asset => resolve(runtimePublicPath, asset))
-          .concat(initialFiles.map(asset => resolve(publicPath, asset))),
+          .map(asset => resolver(runtimePublicPath, asset))
+          .concat(initialFiles.map(asset => resolver(publicPath, asset))),
       };
     }
     const offset = runtime.all.length;


### PR DESCRIPTION
1. support http:// format in publicPath and runtime publicPath
2. add client-fetch-loader in webpack tsx rule